### PR TITLE
Add netcore3.1 support

### DIFF
--- a/BeginCollectionItemCore/BeginCollectionItemCore.csproj
+++ b/BeginCollectionItemCore/BeginCollectionItemCore.csproj
@@ -2,19 +2,19 @@
 
   <PropertyGroup>
     <AssemblyTitle>BeginCollectionItemCore</AssemblyTitle>
-    <VersionPrefix>1.1.0</VersionPrefix>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <VersionPrefix>1.1.1</VersionPrefix>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>BeginCollectionItemCore</AssemblyName>
     <PackageId>BeginCollectionItemCore</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Authors>Saad Farooq (ASP.Net Core Nuget Package), Dan Ludwig and hazzik (MVC 2+ Nuget Package), Steven Sanderson (Original Author)</Authors>
-    <Description>This Html Helper leverages the default model binder in ASP.NET Core 1.0 and higher to materialize viewmodel collection properties from an HTTP POST. It will also work with ASP.Net Core on .Net Framework 4.6.</Description>
+    <Description>This Html Helper leverages the default model binder in ASP.NET Core 3.1 and 5.0 to materialize viewmodel collection properties from an HTTP POST.</Description>
     <PackageProjectUrl>https://github.com/saad749/BeginCollectionItemCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/saad749/BeginCollectionItemCore</RepositoryUrl>
     <PackageTags>BeginCollectionItem HtmlHelper ASP.Net Core AspNetCore MVC BeginCollectionItemCore</PackageTags>
-    <PackageReleaseNotes>1.1.0: Updated to Target .Net 5.0</PackageReleaseNotes>
+    <PackageReleaseNotes>1.1.1: Updated to Target netcoreapp3.1 and .Net 5.0</PackageReleaseNotes>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -24,10 +24,4 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
 </Project>

--- a/BeginCollectionItemCore/BeginCollectionItemCore.nuspec
+++ b/BeginCollectionItemCore/BeginCollectionItemCore.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BeginCollectionItemCore</id>
-    <version>1.0.8</version>
+    <version>1.1.1</version>
     <title>BeginCollectionItemCore</title>
     <authors>Authored by Steve Sanderson, NuGet Package by Dan Ludwig and hazzik, .Net Core Package by Saad Farooq</authors>
     <owners>Saad Farooq</owners>
@@ -10,8 +10,8 @@
     <projectUrl>https://github.com/saad749/BeginCollectionItemCore</projectUrl>
     <!--<iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>-->
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>This Html Helper leverages the default model binder in ASP.NET Core 1.0 and higher to materialize viewmodel collection properties from an HTTP POST.</description>
-    <releaseNotes>This Html Helper leverages the default model binder in ASP.NET Core 1.0 and higher to materialize viewmodel collection properties from an HTTP POST.</releaseNotes>
+    <description>This Html Helper leverages the default model binder in ASP.NET Core MVC 3.1 and 5.0 and higher to materialize viewmodel collection properties from an HTTP POST.</description>
+    <releaseNotes>This Html Helper leverages the default model binder in ASP.NET Core MVC 3.1 and 5.0 to materialize viewmodel collection properties from an HTTP POST.</releaseNotes>
     <copyright>Copyright 2016</copyright>
     <tags>BeginCollectionItem, HtmlHelper, ASP.Net Core, AspNetCore, MVC, BeginCollectionItemCore</tags>
   </metadata>

--- a/BeginCollectionItemCoreDemo/BeginCollectionItemCoreDemo.csproj
+++ b/BeginCollectionItemCoreDemo/BeginCollectionItemCoreDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>BeginCollectionItemCoreDemo</AssemblyName>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
BeginItemCollectionCore 1.0.9 links against netcoreapp2.0 and has a package reference to Microsoft.AspNetCore.All version 2.0.9. The new 1.1.0 net5.0 with a framework reference to Microsoft.AspNetCore.App.

That means if you have a netcoreapp3.1 MVC app with a nuget package reference to BeginItemCollectionCore, you get the 2.0.9 version. It brings with it the Microsoft.AspNetCore.App package version 2.0.9 which includes:

```
    Microsoft.AspNetCore.All 2.0.9
      -> Microsoft.Extensions.Caching 2.0.2
        -> Microsoft.Extensions.Caching.Redis 2.0.2 [deprecated]
          -> StackExchange.Redis.StrongName 1.2.4 [deprectated]
```
This creates a problem that prevents the application from compiling if you are using Redis caching because the netcoreapp3.1 Microsoft.NET.Sdk.Web contains a reference to new libraries for Redis caching.

```
    Microsoft.NET.Sdk.Web
      -> Microsoft.Extensions.Caching
        -> Microsoft.Extensions.Caching.StackExchangeRedis
          -> StackExchange.Redis
```

Both sets of libraries include the `StackExchange.Redis.ConnectionMultiplexer` type which causes the compilation to fail:

```
Startup.cs(49,33): error CS0433: The type 'ConnectionMultiplexer' exists in both 'StackExchange.Redis.StrongName, Version=1.2.4.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46' and 'StackExchange.Redis, Version=2.0.0.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46'
```

I think the best solution is to build add a netcoreapp3.1 build artifact to your nuget package. 

I've modified your csproj files to target both netcoreapp3.1 and net5.0. This completely solves the issue for me.